### PR TITLE
update hvplot 0.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,27 +9,25 @@ source:
   sha256: 8630dba34969b105e267cbe14237e2d56d9969c801980ae5e5190bc18b2792d6
 
 build:
+  skip: True # [py<36]
   number: 0
-  # ModuleNotFoundError: No module named 'hvplot.__main__'
-  # entry_points:
-  #   - hvplot = hvplot.__main__:main
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python
-    - pyct
+    - pyct >=0.4.4
+    - param >=1.12.0
     - pip
     - setuptools
     - wheel
   run:
     - python
     - packaging
-    - param >=1.12.0
     - bokeh >=2.0.0
     - colorcet >=2
     - holoviews >=1.12.0
-    - numpy
+    - numpy >=1.15    
     - pandas
 
 test:
@@ -48,7 +46,7 @@ about:
   license_file: LICENSE
   summary: A high-level plotting API for the PyData ecosystem built on HoloViews
   dev_url: https://github.com/holoviz/hvplot
-  doc_url: https://nbsite.holoviz.org/
+  doc_url: https://hvplot.holoviz.org
 extra:
   recipe-maintainers:
     - CurtLH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,8 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: A high-level plotting API for the PyData ecosystem built on HoloViews
-
+  dev_url: https://github.com/holoviz/hvplot
+  doc_url: https://nbsite.holoviz.org/
 extra:
   recipe-maintainers:
     - CurtLH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.3" %}
+{% set version = "0.8.0" %}
 
 package:
   name: hvplot
@@ -6,27 +6,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/h/hvplot/hvplot-{{ version }}.tar.gz
-  sha256: 74b269c6e118dd6f7d2a4039e91f16a193638f4119b4358dc6dbd58a2e71e432
+  sha256: 8630dba34969b105e267cbe14237e2d56d9969c801980ae5e5190bc18b2792d6
 
 build:
-  number: 1
-  noarch: python
+  number: 0
+  # ModuleNotFoundError: No module named 'hvplot.__main__'
+  # entry_points:
+  #   - hvplot = hvplot.__main__:main
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python
+    - pyct
     - pip
-    - wheel
     - setuptools
-    - pyct >=0.4.4
-    - param >=1.6.1
+    - wheel
   run:
     - python
-    - bokeh >=1.0.0
+    - packaging
+    - param >=1.12.0
+    - bokeh >=2.0.0
     - colorcet >=2
-    - holoviews >=1.11.0
-    - numpy >=1.15
+    - holoviews >=1.12.0
+    - numpy
     - pandas
 
 test:
@@ -39,13 +42,11 @@ test:
     - pip
 
 about:
-  home: https://hvplot.holoviz.org/
+  home: https://hvplot.holoviz.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: A high-level plotting API for the PyData ecosystem built on HoloViews
-  dev_url: https://github.com/holoviz/hvplot
-  doc_url: https://nbsite.holoviz.org/
 
 extra:
   recipe-maintainers:
@@ -53,3 +54,4 @@ extra:
     - jbednar
     - ocefpaf
     - philippjfr
+    - maximlt


### PR DESCRIPTION
Version bump from 0.7.3 to 0.8.0:
---> There seems to be a few inconsistencies between the upstream requirements and the Conda-forge recipe (which is maintained by thehvplot maintainers)
  

1. Upstream requires a version of **bokeh >=1.0.0**
Comparatively, conda-forge requires a version of **bokeh >=2.0.0**

- https://github.com/holoviz/hvplot/blob/04f6dae12c449987abf69601be47c1e292e1ab3a/setup.py#L31
- https://github.com/conda-forge/hvplot-feedstock/blob/92ab82cd9dc23e697a1f7b1fe8757954062ed87e/recipe/meta.yaml#L28

2. Upstream requires a version **holoviews >=1.11.0**
Conda-forge requires a version of **holoviews >=1.12.0**

- https://github.com/holoviz/hvplot/blob/04f6dae12c449987abf69601be47c1e292e1ab3a/setup.py#L33
- https://github.com/conda-forge/hvplot-feedstock/blob/92ab82cd9dc23e697a1f7b1fe8757954062ed87e/recipe/meta.yaml#L30