### PR TITLE
Rebuild 0.8.0 b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - packaging 
+    - packaging
     - bokeh >=2.0.0
     - colorcet >=2
     - holoviews >=1.12.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python
     - packaging
-    # Do not build qith bokeh >=3.0.0, because it has breaking changes 
+    # Do not build with bokeh >=3.0.0, because it has breaking changes 
     - bokeh >=2.0.0,<3.0.0
     - colorcet >=2
     - holoviews >=1.12.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,21 +10,22 @@ source:
 
 build:
   skip: True # [py<36]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python
-    - pyct >=0.4.4
-    - param >=1.12.0
+    - pyct
+    - param
     - pip
     - setuptools
     - wheel
   run:
     - python
     - packaging
-    - bokeh >=2.0.0
+    # Do not build qith bokeh >=3.0.0, because it has breaking changes 
+    - bokeh >=2.0.0,<3.0.0
     - colorcet >=2
     - holoviews >=1.12.0
     - numpy >=1.15    

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,8 @@ requirements:
     - wheel
   run:
     - python
-    - packaging
-    # Do not build with bokeh >=3.0.0, because it has breaking changes 
-    - bokeh >=2.0.0,<3.0.0
+    - packaging 
+    - bokeh >=2.0.0
     - colorcet >=2
     - holoviews >=1.12.0
     - numpy >=1.15    


### PR DESCRIPTION
Rebuild for compatibility with bokeh.

Actions:
1. Bump build number
2. Remove pinnings from `host`
3. Fix `bokeh` pinning