### PR TITLE
hvplot 0.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.0" %}
+{% set version = "0.8.1" %}
 
 package:
   name: hvplot
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/h/hvplot/hvplot-{{ version }}.tar.gz
-  sha256: 8630dba34969b105e267cbe14237e2d56d9969c801980ae5e5190bc18b2792d6
+  sha256: 53ddfe06743c4d5924fb1e597655bfa14e80feaf57a438bfd28442d36ac7c2b6
 
 build:
   skip: True # [py<36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True # [py<36]
+  # panel >=0.13.0 and nodejs aren't available on s390x
+  skip: True # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,32 +1,33 @@
+{% set name = "hvplot" %}
 {% set version = "0.8.1" %}
 
 package:
-  name: hvplot
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/h/hvplot/hvplot-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
   sha256: 53ddfe06743c4d5924fb1e597655bfa14e80feaf57a438bfd28442d36ac7c2b6
 
 build:
-  skip: True # [py<36]
   number: 0
+  skip: True # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python
-    - pyct >=0.4.4
-    - param >=1.12.0
+    - pyct
+    - param
     - pip
     - setuptools
     - wheel
   run:
     - python
     - packaging
-    - bokeh >=2.0.0
+    - bokeh >=1.0.0
     - colorcet >=2
-    - holoviews >=1.12.0
+    - holoviews >=1.11.0
     - numpy >=1.15    
     - pandas
 
@@ -45,8 +46,11 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: A high-level plotting API for the PyData ecosystem built on HoloViews
+  description: |
+    A high-level plotting API for pandas, dask, xarray, and networkx built on HoloViews
   dev_url: https://github.com/holoviz/hvplot
   doc_url: https://hvplot.holoviz.org
+
 extra:
   recipe-maintainers:
     - CurtLH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,10 @@ build:
 requirements:
   host:
     - python
-    - pyct
-    - param
+    - pyct >=0.4.4
+    - param >=1.7.0
     - pip
-    - setuptools
+    - setuptools >=30.3.0
     - wheel
   run:
     - python


### PR DESCRIPTION
**Jira ticket:** [PKG-731](https://anaconda.atlassian.net/browse/PKG-731) (hvplot-0.8.1)

**The upstream data:**
Github releases:  https://github.com/holoviz/hvplot/releases
[Diff between the latest and previous upstream releases](https://github.com/holoviz/hvplot/compare/0.8.0...0.8.1)
License: https://github.com/holoviz/hvplot/blob/master/LICENSE
Changelog: https://github.com/holoviz/hvplot/blob/master/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/holoviz/hvplot/blob/v0.8.1/setup.py
 *  pyproject.toml:  https://github.com/holoviz/hvplot/blob/v0.8.1/pyproject.toml

**_Actions:_**

1. Skip `s390x`
2. Remove pinnings from `host`
3. Update `run` pinnings
4. Add a `description`

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda_affiliated | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.8.1
 * Release on PyPi:
    * version: 0.8.1
    * date: 2022-08-26T12:37:12
* [PyPi history](https://pypi.org/project/hvplot/#history)
 * Popularity: 
    * 3 months downloads: 308625.0
    * All time:  261677 downloads -  hvplot  0.8.1  A high-level plotting API for the PyData ecosystem built on HoloViews  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/holoviz/hvplot/tree/v0.8.1 exists
5. - [x] https://hvplot.holoviz.org is present
6. - [x] Check the pinnings
7. - [x] https://github.com/holoviz/hvplot/blob/master/CHANGELOG.md exists
8. - [x] Additional research
    https://github.com/holoviz/hvplot/issues
    200
9. - [x] `dev_url` is present
    https://github.com/holoviz/hvplot
10. - [x] `doc_url` is present
    https://hvplot.holoviz.org
11. - [x] Verify that the `build_number` is correct
12. - [x] has `setuptools`
13. - [x] has `wheel`
14. - [x] `pip` in test
15. - [x] Verify the test section
16. - [ x Verify if the package is `architecture specific`
17. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
18.  - [x] license_file: LICENSE is present
19. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

20. - [x] license_family BSD is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/hvplot-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/hvplot-feedstock/tree/0.8.1)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/hvplot)
* [Diff between upstream and feature branch](https://github.com/conda-forge/hvplot-feedstock/compare/main...AnacondaRecipes:0.8.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/hvplot-feedstock/compare/master...AnacondaRecipes:0.8.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/hvplot-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.8.1 git@github.com:AnacondaRecipes/hvplot-feedstock.git
```
