### PR TITLE
Update to 0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.8.4" %}
+{% set version = "0.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: eff5fda9713134ac0df3d2648a11897ee40a09b1a2561ad33018802e18b87c22
+  sha256: 064c6757dd10c498d062a3740dd8c66e33e634368337d8540633bb9d0b5eede8
 
 build:
   number: 0


### PR DESCRIPTION
Only change required in the *run* section was adding an upper pin to Param, based on https://github.com/holoviz/hvplot/compare/v0.8.4...v0.9.0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7.