### PR TITLE
Update to 0.9.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.9.0" %}
+{% set version = "0.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: 064c6757dd10c498d062a3740dd8c66e33e634368337d8540633bb9d0b5eede8
+  sha256: 281d189a212d264193f78e3a934efda16a93c0164c4854da9335b42ee0656b3a
 
 build:
   number: 0
@@ -33,7 +33,7 @@ requirements:
     - packaging
     - pandas
     - panel >=0.11.0
-    - param >=1.9.0,<3.0
+    - param >=1.12.0,<3.0
 
 test:
   imports:


### PR DESCRIPTION
hvplot 0.9.1

**Destination channel:** defaults

### Links

Following up the release of hvPlot 0.9.1, done exactly like in https://github.com/conda-forge/hvplot-feedstock/pull/25/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a

### Explanation of changes:

- Simple bump of the version, plus adjustments of the minimum version required of the runtime dependency `param`.
