### PR TITLE
Update to 0.9.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.9.1" %}
+{% set version = "0.9.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: 281d189a212d264193f78e3a934efda16a93c0164c4854da9335b42ee0656b3a
+  sha256: 9a8c9e9249139aaa3dee5f1cea0f93cf36374d179e986705fcddc2b92c470793
 
 build:
   number: 0


### PR DESCRIPTION
hvplot 0.9.2

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/hvplot)
- [Upstream changelog/diff](https://github.com/holoviz/hvplot/compare/v0.9.1...v0.9.2)

### Explanation of changes:

- Like on conda-forge: https://github.com/conda-forge/hvplot-feedstock/pull/26/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a
