### PR TITLE
Update to 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.9.2" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: 9a8c9e9249139aaa3dee5f1cea0f93cf36374d179e986705fcddc2b92c470793
+  sha256: e87486a95bfe151ab52ef163a5e93d9cbd043992cf0b755ccadd2bf36fedd376
 
 build:
   number: 0
@@ -19,10 +19,9 @@ build:
 requirements:
   host:
     - python
-    - pyct
-    - param
     - pip
     - setuptools
+    - setuptools_scm >=6
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # panel >=0.13.0 and nodejs aren't available on s390x
-  skip: True # [py<36 or s390x]
+  skip: True # [py<38 or s390x]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools_scm >=6
+    - setuptools_scm
     - wheel
   run:
     - python


### PR DESCRIPTION
hvplot 0.10.0

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/hvplot/tree/v0.10.0)
- [Upstream changelog/diff](https://github.com/holoviz/hvplot/compare/v0.9.2...v0.10.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)

### Explanation of changes:

- Same as https://github.com/conda-forge/hvplot-feedstock/pull/27/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a
- hvPlot migrated away from `setup.py` to `pyproject.toml`, dropping `pyct` and `param` as build dependencies in favor of the additional `setuptools_scm`.
