### PR TITLE
Update to 0.11.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.10.0" %}
+{% set version = "0.11.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: e87486a95bfe151ab52ef163a5e93d9cbd043992cf0b755ccadd2bf36fedd376
+  sha256: f3bf7a1dd585e4fda3e97854531c43fb920157b2c500b9e63dd36401ffe28034
 
 build:
   number: 0
   # panel >=0.13.0 and nodejs aren't available on s390x
-  skip: True # [py<38 or s390x]
+  skip: True # [py<39 or s390x]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -25,13 +25,13 @@ requirements:
     - wheel
   run:
     - python
-    - bokeh >=1.0.0
+    - bokeh >=3.1
     - colorcet >=2
-    - holoviews >=1.11.0
-    - numpy >=1.15
+    - holoviews >=1.19.0
+    - numpy >=1.21
     - packaging
-    - pandas
-    - panel >=0.11.0
+    - pandas >=1.3
+    - panel >=1.0
     - param >=1.12.0,<3.0
 
 test:


### PR DESCRIPTION
hvplot 0.11.0

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/hvplot)
- [Upstream changelog/diff](https://github.com/holoviz/hvplot/compare/v0.10.0...v0.11.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)
- https://github.com/conda-forge/hvplot-feedstock/pull/30/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a

### Explanation of changes:

- In this release, hvPlot dropped support for Python 3.8 and bumped the version of some of its dependencies (https://github.com/holoviz/hvplot/pull/1355)

