### PR TITLE
Update to 0.11.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.11.0" %}
+{% set version = "0.11.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: f3bf7a1dd585e4fda3e97854531c43fb920157b2c500b9e63dd36401ffe28034
+  sha256: 989ed0389189adc47edcd2601d2eab18bf366e74b07f5e2873e021323c4a14bb
 
 build:
   number: 0


### PR DESCRIPTION
hvplot 0.11.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/hvplot)
- [Upstream changelog/diff](https://github.com/holoviz/hvplot/compare/v0.11.0...v0.11.1)

### Explanation of changes:

- Small patch release with no dependency updates, see the conda-forge recipe https://github.com/conda-forge/hvplot-feedstock/pull/32/files
