### PR TITLE
Update to 0.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
     - hvplot.pandas
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.11.1" %}
+{% set version = "0.11.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: 989ed0389189adc47edcd2601d2eab18bf366e74b07f5e2873e021323c4a14bb
+  sha256: b7ad1f2f1c705e47e26b22c89c11711a84f7774faaabab756b45e8d1e00a6010
 
 build:
   number: 0


### PR DESCRIPTION
hvplot 0.11.2

**Destination channel:** defaults

### Links

- ~~[{ticket_number}]()~~
- [Upstream repository](https://github.com/holoviz/hvplot)
- [Upstream changelog/diff](https://github.com/holoviz/hvplot/compare/v0.11.1...v0.11.2#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)
- Relevant dependency PRs:
  - None

### Explanation of changes:

- Patch release with no dependency update
