### PR TITLE
Update to 0.11.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hvplot" %}
-{% set version = "0.11.2" %}
+{% set version = "0.11.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hvplot-{{ version }}.tar.gz
-  sha256: b7ad1f2f1c705e47e26b22c89c11711a84f7774faaabab756b45e8d1e00a6010
+  sha256: ce82dea296af6146b9a51aa5ed1f772e5415a07c6c33a4eae0f00bbe7ec880ca
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,7 @@ source:
 
 build:
   number: 0
-  # panel >=0.13.0 and nodejs aren't available on s390x
-  skip: True # [py<39 or s390x]
+  skip: True # [py<39]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
hvPlot 0.11.3

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/hvplot)
- [Upstream changelog/diff](https://github.com/holoviz/hvplot/compare/v0.11.2...v0.11.3)

### Explanation of changes:

- Patch release with no dependency change
